### PR TITLE
Fix directory review warnings (1.0.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ power and Style Settings options, tuned for everyday writing and note-taking.
 
 ## Install
 
-### From the Community Themes browser *(coming soon)*
+### From the Community Themes browser
 
 `Settings → Appearance → Manage → Browse`, search for **Wololoo**, install and apply.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,7 @@
 {
   "name": "Wololoo",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "minAppVersion": "0.16.0",
   "author": "@raulanatol",
-  "authorUrl": "https://twitter.com/raulanatol",
-  "description": "A warm, focused remix of Catppuccin for Obsidian. Ships Mocha by default, supports Latte/Frappe/Macchiato and the full Catppuccin accent palette via Style Settings."
+  "authorUrl": "https://twitter.com/raulanatol"
 }

--- a/theme.css
+++ b/theme.css
@@ -2251,8 +2251,6 @@ body {
 * Hide icons with Style Settings
 */
 .ctp-icon-hide .nav-folder .nav-folder-title .nav-folder-title-content::before,
-.ctp-icon-hide .nav-folder.is-collapsed .nav-folder-title .nav-folder-title-content::before,
-.ctp-icon-hide .nav-folder .nav-folder-title .nav-folder-title-content::before,
 .ctp-icon-hide .nav-folder.is-collapsed .nav-folder-title .nav-folder-title-content::before {
     display: none;
 }
@@ -2601,17 +2599,8 @@ body:not(.ctp-tag-pill) .cm-hashtag::selection {
     font-variant: all-small-caps;
 }
 
-.search-suggest-item.is-selected {
-    background-color: rgb(var(--ctp-accent));
-    color: var(--text-on-accent);
-}
-
 .search-suggest-item.is-selected .list-item-part.clickable-icon {
     color: var(--text-muted);
-}
-
-.search-suggest-item.is-selected .search-suggest-info-text {
-    color: var(--text-on-accent);
 }
 
 .list-item-part.clickable-icon:hover,
@@ -3847,7 +3836,6 @@ input[data-task="<"]:checked,
 li[data-task="<"] > input:checked,
 li[data-task="<"] > p > input:checked {
     color: var(--text-faint);
-    -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' class='h-5 w-5' viewBox='0 0 20 20' fill='currentColor'%3E%3Cpath fill-rule='evenodd' d='M10 18a8 8 0 100-16 8 8 0 000 16zm1-12a1 1 0 10-2 0v4a1 1 0 00.293.707l2.828 2.829a1 1 0 101.415-1.415L11 9.586V6z' clip-rule='evenodd' /%3E%3C/svg%3E");
     -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' class='h-5 w-5' viewBox='0 0 20 20' fill='currentColor'%3E%3Cpath fill-rule='evenodd' d='M6 2a1 1 0 00-1 1v1H4a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V6a2 2 0 00-2-2h-1V3a1 1 0 10-2 0v1H7V3a1 1 0 00-1-1zm0 5a1 1 0 000 2h8a1 1 0 100-2H6z' clip-rule='evenodd' /%3E%3C/svg%3E");
 }
 


### PR DESCRIPTION
## Summary

Addresses the warnings reported by the Obsidian community directory review of `1.0.0`, and bumps the manifest to `1.0.1` ready for a re-review.

### Fixed

- **Theme manifest** — drop the `description` field; theme manifests don't accept it (it's a plugin-manifest-only field). Resolves `Manifest contains unknown field description`.
- **README** — replace `*(coming soon)*` with a real heading under the Community Themes browser section. Resolves `README contains unfilled placeholder text`.
- **theme.css** — remove a duplicated `-webkit-mask-image` declaration inside the `[<] Schedule` task rule (the second one was silently shadowing the first). Resolves `Unexpected duplicate "-webkit-mask-image"`.
- **theme.css** — collapse the four-selector list of `.ctp-icon-hide .nav-folder ...` into the two unique selectors. Resolves the duplicate-selector warnings at 2255/2256.
- **theme.css** — remove two fully duplicate `.search-suggest-item.is-selected` rule blocks (background/color and `.search-suggest-info-text`). Resolves the duplicate-selector warnings at 2604/2613.

### Not addressed (warnings inherited from upstream Catppuccin)

These are non-blocking warnings that we'll handle as a separate cleanup since they carry visual-regression risk and need testing inside Obsidian:

- `text-decoration-color` / `-line` / `-style` longhands flagged as partially supported. Many call sites use them standalone; converting to the shorthand needs care.
- `!important` overrides at ~30 lines. Several are needed to win against Obsidian's defaults; this needs visual verification per case.
- Multi-block redefinitions of `body`, `.theme-light, .theme-dark` — these are conscious section-by-section overrides in the upstream, not literal duplicates.

## Next steps after merge

- [ ] Tag `1.0.1`, create a GitHub Release with `manifest.json` + `theme.css`.
- [ ] Push the new release to the community directory for re-review.

## Test plan

- [ ] Manifest still parses (`jq . manifest.json`).
- [ ] Theme loads in light and dark mode and the `[<]` task checkbox still shows the calendar icon.
- [ ] The Style Settings "Catppuccin: Icon Styles → Hide icons" toggle still hides folder icons.
- [ ] Search-suggest selected state still has the accent background.