### PR TITLE
feat(snippets): add company link-type icon

### DIFF
--- a/snippets/wololoo.css
+++ b/snippets/wololoo.css
@@ -2,3 +2,28 @@
 .nav-folder.mod-root > .nav-folder-title .nav-folder-title-content {
     display: none;
 }
+
+/* People / Company link-type icons */
+a.internal-link[data-link-type~="people"]::before {
+    content: "👤 ";
+}
+
+a.internal-link[data-link-type~="person"]::before {
+    content: "👤 ";
+}
+
+a.internal-link[data-link-type~="company"]::before {
+    content: "🏢 ";
+}
+
+span[data-link-type="people"] > span::before {
+    content: '👤 ';
+}
+
+span[data-link-type="person"] > span::before {
+    content: '👤 ';
+}
+
+span[data-link-type="company"] > span::before {
+    content: '🏢 ';
+}


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Changes

- Add `🏢` icon for `data-link-type="company"` on both `a.internal-link` and inline `span` variants in `snippets/wololoo.css`
- Restore the `people` / `person` rules (`👤`) that were dropped in the Migration commit, so the snippet is self-sufficient and does not depend on vault-local CSS

## Pay attention to:

- All rules live in the optional snippet `snippets/wololoo.css`, not in `theme.css`. To see the icons in a vault, the snippet must be copied to `.obsidian/snippets/` and enabled under Settings → Appearance → CSS snippets.
- A wikilink like `[[People/B/bbva|BBVA]]` in a note with `type: company` renders as `🏢 BBVA`; `[[People/A/ana|Ana]]` with `type: people` continues rendering as `👤 Ana`.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
