### PR TITLE
Reduce heading font sizes

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -185,12 +185,12 @@ body {
     --h4-line-height: 1.5;
     --h5-line-height: var(--line-height-normal);
     --h6-line-height: var(--line-height-normal);
-    --h1-size: 2em;
-    --h2-size: 1.6em;
-    --h3-size: 1.37em;
-    --h4-size: 1.25em;
-    --h5-size: 1.12em;
-    --h6-size: 1.12em;
+    --h1-size: 1.6em;
+    --h2-size: 1.35em;
+    --h3-size: 1.2em;
+    --h4-size: 1.1em;
+    --h5-size: 1em;
+    --h6-size: 1em;
     --h1-style: normal;
     --h2-style: normal;
     --h3-style: normal;


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Changes

- Reduce all heading sizes (`--h1-size` through `--h6-size`) in `theme.css` so they read as less oversized:
  - h1: `2em` → `1.6em`
  - h2: `1.6em` → `1.35em`
  - h3: `1.37em` → `1.2em`
  - h4: `1.25em` → `1.1em`
  - h5: `1.12em` → `1em`
  - h6: `1.12em` → `1em`

## Pay attention to:

- The inline title (file title) inherits from `--h1-size`, so it shrinks accordingly too.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
