### PR TITLE
chore: bump version to 1.0.2

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Wololoo",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "minAppVersion": "0.16.0",
   "author": "@raulanatol",
   "authorUrl": "https://twitter.com/raulanatol"


### PR DESCRIPTION
## Pull request type

- [x] Other: release version bump

## Changes

- Bump `manifest.json` version `1.0.1` → `1.0.2` to publish the unreleased changes since 1.0.1:
  - Company link-type icon + restored people/person rules (#5)
  - Reduced heading font sizes (#6)

## Pay attention to:

- After merge, a `1.0.2` git tag + GitHub release (with `manifest.json` and `theme.css`) must be created so Obsidian picks up the new version.